### PR TITLE
修改updateData对象，将image_url相关逻辑改为cover_img

### DIFF
--- a/app/api/prompts/[id]/route.js
+++ b/app/api/prompts/[id]/route.js
@@ -30,7 +30,7 @@ export async function POST(request, { params }) {
   const { userId } = await auth()
   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON_KEY);
 
-  const { title, content, description, is_public, tags, image_url ,version} = await request.json();
+  const { title, content, description, is_public, tags, cover_img ,version} = await request.json();
 
   const { data: prompt, error } = await supabase
     .from('prompts')
@@ -53,7 +53,7 @@ export async function POST(request, { params }) {
   if (description !== undefined) updateData.description = description;
   if (is_public !== undefined) updateData.is_public = is_public;
   if (tags !== undefined) updateData.tags = tags;
-  if (image_url !== undefined) updateData.image_url = image_url;
+  if (cover_img !== undefined) updateData.cover_img = cover_img;
   if(version !== undefined) updateData.version = version;
 
   const { error: updateError } = await supabase


### PR DESCRIPTION
修复了提示词封面图片无法保存的问题修改app/api/prompts/[id]/route.js中，POST请求体的解构，将image_url改为cover_img。修改updateData对象，将image_url相关逻辑改为cover_img。